### PR TITLE
Не отображать 0, когда нет непрочитанных сообщений

### DIFF
--- a/src/components/messages/chat/List.vue
+++ b/src/components/messages/chat/List.vue
@@ -41,7 +41,7 @@
     </div>
 
     <div :class="['im_scroll_end_btn', { hidden: !showEndBtn }]" @click="scrollToEnd">
-      <div>{{ peer && convertCount(peer.unread) || '' }}</div>
+      <div>{{ peer && peer.unread > 0 && convertCount(peer.unread) || '' }}</div>
       <img src="~assets/dropdown.webp">
     </div>
   </Scrolly>


### PR DESCRIPTION
В некоторых случаях на кнопке прокрутки вниз отображается 0, когда нет непрочитанных сообщений:
![image](https://user-images.githubusercontent.com/51704055/90343473-45519480-e019-11ea-9d38-d3046c6db8b1.png)

Этот PR исправляет это, теперь число отображается только если есть непрочитанные сообщения
