### PR TITLE
fix: allow zero cmid in some cases

### DIFF
--- a/src/actions/loadInitialData.ts
+++ b/src/actions/loadInitialData.ts
@@ -29,9 +29,14 @@ export async function loadInitialData(onError: () => void) {
       })
     ])
 
-    connection.status = 'connected'
-    engine.start(longpollParams)
-    engine.stop()
+    for (const apiUser of conversations.profiles ?? []) {
+      const user = fromApiUser(apiUser)
+      peers.set(user.id, user)
+    }
+    for (const apiGroup of conversations.groups ?? []) {
+      const group = fromApiGroup(apiGroup)
+      peers.set(group.id, group)
+    }
 
     for (const apiConvo of conversations.items) {
       const {
@@ -47,18 +52,14 @@ export async function loadInitialData(onError: () => void) {
       }
     }
 
-    for (const apiUser of conversations.profiles ?? []) {
-      const user = fromApiUser(apiUser)
-      peers.set(user.id, user)
-    }
-    for (const apiGroup of conversations.groups ?? []) {
-      const group = fromApiGroup(apiGroup)
-      peers.set(group.id, group)
-    }
+    connection.status = 'connected'
+    engine.start(longpollParams)
+    engine.stop()
 
     convoList.loading = false
     convoList.hasMore = conversations.items.length === CONVOS_PER_PAGE
-  } catch {
+  } catch (err) {
+    console.warn('Ошибка начальной загрузки данных', err)
     connection.status = 'initFailed'
     onError()
   }

--- a/src/converters/ConvoConverter.ts
+++ b/src/converters/ConvoConverter.ts
@@ -41,8 +41,8 @@ export function fromApiConvo(
     enabledNotifications: !apiConvo.push_settings,
     majorSortId: apiConvo.sort_id?.major_id ?? 0,
     minorSortId: apiConvo.sort_id?.minor_id ?? 0,
-    inReadBy: Message.resolveCmid(apiConvo.in_read_cmid),
-    outReadBy: Message.resolveCmid(apiConvo.out_read_cmid)
+    inReadBy: Message.resolveCmid(apiConvo.in_read_cmid, true),
+    outReadBy: Message.resolveCmid(apiConvo.out_read_cmid, true)
   } satisfies Partial<Convo.Convo>
 
   const peerId = Peer.resolveId(apiConvo.peer.id)

--- a/src/model/Message.ts
+++ b/src/model/Message.ts
@@ -82,8 +82,8 @@ export type ServiceAction =
     }
   | { type: 'unknown' }
 
-export function resolveCmid(cmid: number): Cmid {
-  if (cmid <= 0) {
+export function resolveCmid(cmid: number, allowZero = false): Cmid {
+  if (!allowZero && cmid <= 0) {
     throw new Error('Message.Cmid = ' + cmid)
   }
 


### PR DESCRIPTION
В случае с inReadBy и outReadBy могут существовать беседы, в которых кто-то из участников никогда не читал сообщения в чате, либо в чате в целом не было сообщений