### PR TITLE
feat: Перенос счетчика сообщений в нижнюю полосу с сообщением

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/src/ui/app/App/App.css
+++ b/src/ui/app/App/App.css
@@ -18,7 +18,7 @@
 }
 
 /* Скроллбар меняется с дефолтного на кастомный только при выставлении стилей в этом селекторе */
-.App:not(.App--isMacOS)::-webkit-scrollbar {
+.App:not(.App--isMacOS) ::-webkit-scrollbar {
   width: 16px;
 }
 

--- a/src/ui/messenger/ConvoList/ConvoList.css
+++ b/src/ui/messenger/ConvoList/ConvoList.css
@@ -49,10 +49,6 @@
   padding: 6px 8px;
 }
 
-.ConvoList__list::-webkit-scrollbar {
-  width: 2px;
-}
-
 .ConvoList__spinner {
   margin: 16px auto;
 }

--- a/src/ui/messenger/ConvoList/ConvoList.css
+++ b/src/ui/messenger/ConvoList/ConvoList.css
@@ -49,6 +49,10 @@
   padding: 6px 8px;
 }
 
+.ConvoList__list::-webkit-scrollbar {
+  width: 2px;
+}
+
 .ConvoList__spinner {
   margin: 16px auto;
 }

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.css
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.css
@@ -54,9 +54,8 @@
 .ConvoListItem__message {
   grid-area: message;
   align-self: start;
-
+  width: calc(100% - 5px);
   display: flex;
-  gap: 8px;
   overflow: hidden;
   color: var(--vkui--color_text_subhead);
 }
@@ -79,11 +78,11 @@
 
 .ConvoListItem__indicators {
   grid-area: indicators;
-  align-self: center;
+  align-self: self-end;
 }
 
 .ConvoListItem__indicators:not(:empty) {
-  margin-left: 5px;
+  transform: translateY(-3px);
 }
 
 .ConvoListItem__compactCounter {

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.css
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.css
@@ -6,7 +6,7 @@
     'avatar message indicators';
   grid-template-rows: 1fr 1fr;
   grid-template-columns: auto 1fr auto;
-  row-gap: 5px;
+  row-gap: 2px;
   padding: 6px 8px;
   margin: 2px 0;
   border-radius: 12px;
@@ -33,7 +33,7 @@
 
 .ConvoListItem__name {
   grid-area: name;
-  align-self: end;
+  align-self: center;
 
   display: flex;
   align-items: center;

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.css
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.css
@@ -78,12 +78,11 @@
 
 .ConvoListItem__indicators {
   grid-area: indicators;
-  align-self: self-end;
+  align-self: self-start;
 }
 
 .ConvoListItem__indicators:not(:empty) {
   margin-left: 5px;
-  margin-bottom: 3px;
 }
 
 .ConvoListItem__compactCounter {

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.css
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.css
@@ -56,6 +56,7 @@
   align-self: start;
 
   display: flex;
+  gap: 8px;
   overflow: hidden;
   color: var(--vkui--color_text_subhead);
 }

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.css
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.css
@@ -53,7 +53,7 @@
 
 .ConvoListItem__message {
   grid-area: message;
-  align-self: start;
+  align-self: center;
 
   display: flex;
   overflow: hidden;
@@ -78,7 +78,7 @@
 
 .ConvoListItem__indicators {
   grid-area: indicators;
-  align-self: self-start;
+  align-self: center;
 }
 
 .ConvoListItem__indicators:not(:empty) {

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.css
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.css
@@ -2,7 +2,7 @@
   display: grid;
   position: relative;
   grid-template-areas:
-    'avatar name indicators'
+    'avatar name name'
     'avatar message indicators';
   grid-template-rows: 1fr 1fr;
   grid-template-columns: auto 1fr auto;
@@ -54,7 +54,7 @@
 .ConvoListItem__message {
   grid-area: message;
   align-self: start;
-  width: calc(100% - 5px);
+
   display: flex;
   overflow: hidden;
   color: var(--vkui--color_text_subhead);
@@ -82,7 +82,8 @@
 }
 
 .ConvoListItem__indicators:not(:empty) {
-  transform: translateY(-3px);
+  margin-left: 5px;
+  margin-bottom: 3px;
 }
 
 .ConvoListItem__compactCounter {

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.tsx
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.tsx
@@ -70,13 +70,12 @@ export const ConvoListItem = defineComponent<Props>((props) => {
             <MessagePreview convo={props.convo} />
           </span>
           <span class="ConvoListItem__date">{lastMessage.value && <MessageDate message={lastMessage.value} />}</span>
-
-          <div class="ConvoListItem__indicators">
-            <Counter
-              count={props.convo.unreadCount}
-              mode={props.convo.enabledNotifications ? 'primary' : 'secondary'}
-            />
-          </div>
+        </div>
+        <div class="ConvoListItem__indicators">
+          <Counter
+            count={props.convo.unreadCount}
+            mode={props.convo.enabledNotifications ? 'primary' : 'secondary'}
+          />
         </div>
       </div>
     )

--- a/src/ui/messenger/ConvoListItem/ConvoListItem.tsx
+++ b/src/ui/messenger/ConvoListItem/ConvoListItem.tsx
@@ -70,13 +70,13 @@ export const ConvoListItem = defineComponent<Props>((props) => {
             <MessagePreview convo={props.convo} />
           </span>
           <span class="ConvoListItem__date">{lastMessage.value && <MessageDate message={lastMessage.value} />}</span>
-        </div>
 
-        <div class="ConvoListItem__indicators">
-          <Counter
-            count={props.convo.unreadCount}
-            mode={props.convo.enabledNotifications ? 'primary' : 'secondary'}
-          />
+          <div class="ConvoListItem__indicators">
+            <Counter
+              count={props.convo.unreadCount}
+              mode={props.convo.enabledNotifications ? 'primary' : 'secondary'}
+            />
+          </div>
         </div>
       </div>
     )

--- a/src/ui/messenger/Messenger/Messenger.css
+++ b/src/ui/messenger/Messenger/Messenger.css
@@ -43,12 +43,12 @@
 
 @media (width > 700px) {
   .Messenger__convoList {
-    width: 45%;
+    width: 42%;
   }
 }
 
-@media (width > 850px) {
+@media (width > 950px) {
   .Messenger__convoList {
-    width: calc(850px * 0.45);
+    width: calc(950px * 0.42);
   }
 }

--- a/src/ui/messenger/Messenger/Messenger.css
+++ b/src/ui/messenger/Messenger/Messenger.css
@@ -49,6 +49,6 @@
 
 @media (width > 850px) {
   .Messenger__convoList {
-    width: calc(850px * 0.42);
+    width: calc(850px * 0.45);
   }
 }

--- a/src/ui/messenger/Messenger/Messenger.css
+++ b/src/ui/messenger/Messenger/Messenger.css
@@ -43,7 +43,7 @@
 
 @media (width > 700px) {
   .Messenger__convoList {
-    width: 42%;
+    width: 45%;
   }
 }
 


### PR DESCRIPTION
Closes #93 

- Перенес счетчик сообщений вниз. 
- Починил scroll который работал не корректно на windows. 
- Увеличил итоговый размер списка чатов (пропорционально размеру экрана)

![image](https://github.com/user-attachments/assets/9aaf71aa-1c98-48bc-9f7b-4a6b372a1969)

